### PR TITLE
Use AstSchemaBuilder from args rather the default one

### DIFF
--- a/src/main/scala/sangria/schema/AstSchemaMaterializer.scala
+++ b/src/main/scala/sangria/schema/AstSchemaMaterializer.scala
@@ -699,7 +699,7 @@ object AstSchemaMaterializer {
     definitions[Any](document, AstSchemaBuilder.default)
 
   def definitions[Ctx](document: ast.Document, builder: AstSchemaBuilder[Ctx]): Vector[Named] =
-    new AstSchemaMaterializer[Ctx](document, AstSchemaBuilder.default).definitions
+    new AstSchemaMaterializer[Ctx](document, builder).definitions
 
   def extendSchema[Ctx, Val](schema: Schema[Ctx, Val], document: ast.Document, builder: AstSchemaBuilder[Ctx] = AstSchemaBuilder.default): Schema[Ctx, Val] =
     new AstSchemaMaterializer[Ctx](document, builder).extend(schema)


### PR DESCRIPTION
On the current implementation `definitions(document, builder)` doesn't use the builder argument at all  and instead always use `AstSchemaBuilder.default`. So this PR make use of the custom builder and pass to the `AstSchemaMaterializer` as an argument.

``` scala
 // This implementation provides the default AstSchemaBuilder
  def definitions(document: ast.Document): Vector[Named] =
    definitions[Any](document, AstSchemaBuilder.default)

 // Here we accept a custom AstSchemaBuilder as an argument but we don't use it. We use the default one instead
  def definitions[Ctx](document: ast.Document, builder: AstSchemaBuilder[Ctx]): Vector[Named] =
    new AstSchemaMaterializer[Ctx](document, AstSchemaBuilder.default).definitions
```

Migrated from https://github.com/sangria-graphql/sangria/pull/420