### PR TITLE
Replace remaining Unicode arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import sangria.marshalling.circe._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 val QueryType = ObjectType("Query", fields[Unit, Unit](
-  Field("hello", StringType, resolve = _ ⇒ "Hello world!")
+  Field("hello", StringType, resolve = _ => "Hello world!")
 ))
 
 val schema = Schema(QueryType)
@@ -54,7 +54,7 @@ val query = graphql"{ hello }"
 
 val result = Executor.execute(schema, query)
 
-result.foreach(res ⇒ println(res.spaces2))
+result.foreach(res => println(res.spaces2))
 ```
 
 this example will print following result JSON:

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ mimaPreviousArtifacts := Set("org.sangria-graphql" %% "sangria" % "1.4.2")
 
 description := "Scala GraphQL implementation"
 homepage := Some(url("http://sangria-graphql.org"))
-licenses := Seq("Apache License, ASL Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0"))
+licenses := Seq("Apache License, ASL Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 scalaVersion := "2.13.0"
 crossScalaVersions := Seq("2.11.12", "2.12.10", scalaVersion.value)
@@ -59,7 +59,7 @@ releaseCrossBuild := true
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 publishMavenStyle := true
 publishArtifact in Test := false
-pomIncludeRepository := (_ ⇒ false)
+pomIncludeRepository := (_ => false)
 publishTo := Some(
   if (isSnapshot.value)
     "snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
@@ -76,6 +76,6 @@ scmInfo := Some(ScmInfo(
 
 // nice *magenta* prompt!
 
-shellPrompt in ThisBuild := { state ⇒
+shellPrompt in ThisBuild := { state =>
   scala.Console.MAGENTA + Project.extract(state).currentRef.project + "> " + scala.Console.RESET
 }


### PR DESCRIPTION
Scala 2.13 deprecates Unicode arrows, and we've removed them from the source here, but this change makes the build and docs consistent.