### PR TITLE
Revert "extend ProjectionNames to include Args"

### DIFF
--- a/modules/core/src/main/scala/sangria/execution/Resolver.scala
+++ b/modules/core/src/main/scala/sangria/execution/Resolver.scala
@@ -1165,7 +1165,7 @@ class Resolver[Ctx](
                       else Vector(field.name)
 
                     projectedName.map (name =>
-                      ProjectedName(name, loop(path.add(astField, objTpe), field.fieldType, fields, currLevel + 1), Args(field, astField)))
+                      ProjectedName(name, loop(path.add(astField, objTpe), field.fieldType, fields, currLevel + 1)))
                 }
                 .flatten
             case Failure(_) => Vector.empty

--- a/modules/core/src/main/scala/sangria/schema/Context.scala
+++ b/modules/core/src/main/scala/sangria/schema/Context.scala
@@ -158,7 +158,7 @@ object Projector {
     }
 }
 
-case class ProjectedName(name: String, children: Vector[ProjectedName] = Vector.empty, args: Args = Args.empty) {
+case class ProjectedName(name: String, children: Vector[ProjectedName] = Vector.empty) {
   lazy val asVector = {
     def loop(name: ProjectedName): Vector[Vector[String]] =
       Vector(name.name) +: (name.children flatMap loop map (name.name +: _))


### PR DESCRIPTION
This reverts commit f9b921915355d2843a5853788cc60b25bc9535f5 as it introduced an issue:
https://github.com/sangria-graphql-org/sangria/pull/10#issuecomment-571471876