### PR TITLE
[WIP]make object type can be empty

### DIFF
--- a/modules/core/src/main/scala/sangria/schema/SchemaValidationRule.scala
+++ b/modules/core/src/main/scala/sangria/schema/SchemaValidationRule.scala
@@ -374,18 +374,12 @@ object ContainerMembersValidator extends SchemaElementValidator {
     validateObjectLikeType(schema, tpe, "Interface")
 
   def validateObjectLikeType(schema: Schema[_, _], tpe: ObjectLikeType[_, _], kind: String): Vector[Violation] = {
-    val emptyErrors =
-      if (tpe.uniqueFields.isEmpty)
-        Vector(EmptyFieldsViolation(kind, tpe.name, sourceMapper(schema), location(tpe)))
-      else Vector.empty
-
     val nonUnique =
       tpe.ownFields.groupBy(_.name).toVector.collect {
         case (fieldName, dup) if dup.size > 1 =>
           NonUniqueFieldsViolation(kind, tpe.name, fieldName, sourceMapper(schema), dup.flatMap(location).toList)
       }
-
-    emptyErrors ++ nonUnique
+    nonUnique
   }
 
   override def validateField(schema: Schema[_, _], tpe: ObjectLikeType[_, _], field: Field[_, _]) =

--- a/modules/core/src/test/scala/sangria/schema/SchemaConstraintsSpec.scala
+++ b/modules/core/src/test/scala/sangria/schema/SchemaConstraintsSpec.scala
@@ -141,7 +141,7 @@ class SchemaConstraintsSpec extends WordSpec with Matchers {
         "Input type 'Input' must define one or more fields.",
         "Interface type 'Interface1' must define one or more fields.",
         "Interface type 'Interface2' must define one or more fields.",
-        "Object type 'Output' must define one or more fields."))
+      ))
     }
 
     "Not allow ObjectTypes with same name to be based on different case classes" in {


### PR DESCRIPTION
when combine more than graphql files, it may be empty for the root schema.
for example:
schema.graphql
```graphql
schema {
    query: Query
    mutation: Mutation
    subscription: Subscription
}
type Query

type Mutation

type Subscription
```
other graphql files will extend this.