### PR TITLE
GraphQLOutputType and GraphQLInputType annotationsField type override annotations

### DIFF
--- a/modules/core/src/main/scala/sangria/macros/derive/DeriveMacroSupport.scala
+++ b/modules/core/src/main/scala/sangria/macros/derive/DeriveMacroSupport.scala
@@ -25,6 +25,12 @@ trait DeriveMacroSupport {
       .collect {case q"new $name($arg)" if name.tpe =:= typeOf[GraphQLName] => arg}
       .headOption
 
+  protected def symbolOutputType(annotations: List[Annotation]): Option[Tree] =
+    annotations
+      .map (_.tree)
+      .collect {case q"new $name($arg)" if name.tpe =:= typeOf[GraphQLOutputType] => arg}
+      .headOption
+
   protected def symbolDescription(annotations: List[Annotation]): Option[Tree] =
     annotations
       .map (_.tree)

--- a/modules/core/src/main/scala/sangria/macros/derive/DeriveMacroSupport.scala
+++ b/modules/core/src/main/scala/sangria/macros/derive/DeriveMacroSupport.scala
@@ -31,6 +31,12 @@ trait DeriveMacroSupport {
       .collect {case q"new $name($arg)" if name.tpe =:= typeOf[GraphQLOutputType] => arg}
       .headOption
 
+  protected def symbolInputType(annotations: List[Annotation]): Option[Tree] =
+    annotations
+      .map (_.tree)
+      .collect {case q"new $name($arg)" if name.tpe =:= typeOf[GraphQLInputType] => arg}
+      .headOption
+
   protected def symbolDescription(annotations: List[Annotation]): Option[Tree] =
     annotations
       .map (_.tree)

--- a/modules/core/src/main/scala/sangria/macros/derive/DeriveObjectTypeMacro.scala
+++ b/modules/core/src/main/scala/sangria/macros/derive/DeriveObjectTypeMacro.scala
@@ -85,6 +85,9 @@ class DeriveObjectTypeMacro(context: blackbox.Context) extends {
           val fieldType = field.method.returnType
           val actualFieldType = findActualFieldType(fieldType)
 
+          val annotationType = symbolOutputType(field.annotations)
+          val implicitGraphqlType = q"implicitly[sangria.macros.derive.GraphQLOutputTypeLookup[$actualFieldType]].graphqlType"
+
           val name = field.name
           val annotationName = symbolName(field.annotations)
           val configName = config.collect{case MacroRenameField(`name`, tree, _) => tree}.lastOption
@@ -116,7 +119,7 @@ class DeriveObjectTypeMacro(context: blackbox.Context) extends {
           q"""
             sangria.schema.Field[$ctxType, $valType, $actualFieldType, $actualFieldType](
               $fieldName,
-              implicitly[sangria.macros.derive.GraphQLOutputTypeLookup[$actualFieldType]].graphqlType,
+              ${annotationType getOrElse implicitGraphqlType},
               ${configDescr orElse annotationDescr},
               $args,
               $resolve,

--- a/modules/core/src/main/scala/sangria/macros/derive/annotations.scala
+++ b/modules/core/src/main/scala/sangria/macros/derive/annotations.scala
@@ -2,7 +2,7 @@ package sangria.macros.derive
 
 import language.existentials
 import sangria.execution.FieldTag
-import sangria.schema.OutputType
+import sangria.schema.{InputType, OutputType}
 
 import scala.annotation.StaticAnnotation
 
@@ -14,3 +14,4 @@ class GraphQLExclude extends StaticAnnotation
 class GraphQLField extends StaticAnnotation
 class GraphQLDefault(defaultValue: T forSome {type T}) extends StaticAnnotation
 class GraphQLOutputType(graphQLType: OutputType[T] forSome {type T}) extends StaticAnnotation
+class GraphQLInputType(graphQLType: InputType[T] forSome {type T}) extends StaticAnnotation

--- a/modules/core/src/main/scala/sangria/macros/derive/annotations.scala
+++ b/modules/core/src/main/scala/sangria/macros/derive/annotations.scala
@@ -1,8 +1,8 @@
 package sangria.macros.derive
 
 import language.existentials
-
 import sangria.execution.FieldTag
+import sangria.schema.OutputType
 
 import scala.annotation.StaticAnnotation
 
@@ -13,3 +13,4 @@ class GraphQLFieldTags(fieldTags: FieldTag*) extends StaticAnnotation
 class GraphQLExclude extends StaticAnnotation
 class GraphQLField extends StaticAnnotation
 class GraphQLDefault(defaultValue: T forSome {type T}) extends StaticAnnotation
+class GraphQLOutputType(graphQLType: OutputType[T] forSome {type T}) extends StaticAnnotation

--- a/modules/core/src/test/scala/sangria/macros/derive/DeriveMacroTestModel.scala
+++ b/modules/core/src/test/scala/sangria/macros/derive/DeriveMacroTestModel.scala
@@ -24,6 +24,7 @@ object DeriveMacroTestModel {
   case class TestSubjectAnnotated(
     @GraphQLDescription("my id")
     @GraphQLDeprecated("No IDs anymore!")
+    @GraphQLOutputType(IDType)
     id: String,
 
     @GraphQLName("myList")


### PR DESCRIPTION
Added macro support for 2 new annotations: GraphQLOutputType and GraphQLInputType
These annotations take a Sangria OutputType or InputType respectively, and uses that as the field type instead of the found implicit type.

This was requested in https://github.com/sangria-graphql/sangria/issues/346