### PR TITLE
Validation for non-breakable chains of circular references in Input Objects

### DIFF
--- a/modules/core/src/main/scala/sangria/validation/Violation.scala
+++ b/modules/core/src/main/scala/sangria/validation/Violation.scala
@@ -608,3 +608,7 @@ case class ExistingTypeViolation(typeName: String, sourceMapper: Option[SourceMa
 case class InvalidTypeUsageViolation(expectedTypeKind: String, tpe: String, sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation {
   lazy val simpleErrorMessage = s"Type '$tpe' is not an $expectedTypeKind type."
 }
+
+case class InputObjectTypeRecursion(name: String, fieldName: String, path: List[String], sourceMapper: Option[SourceMapper], locations: List[AstLocation]) extends AstNodeViolation  {
+  lazy val simpleErrorMessage: String = s"Cannot reference InputObjectType '$name' within itself through a series of non-null fields: '$fieldName${if (path.isEmpty) "" else "."}${path.mkString(".")}'."
+}


### PR DESCRIPTION
This PR adds a missing validation step for Input Objects which have non-breakable chains of circular references.

More details bellow:

Input Objects are allowed to reference other Input Objects. A circular reference occurs
when an Input Object references itself either directly or through subordinated Input Objects.

Circular references are generally allowed, however they may not be defined as an
unbroken chain of Non-Null fields. Such Input Objects are invalid, because there
is no way to provide a legal value for them.

The following examples are allowed:

```graphql
input Example {
  self: Example
  value: String
}
```

This is fine because a value for `self` may simply be omitted from the arguments.

```graphql
input Example {
  self: [Example!]!
  value: String
}
```

This also works as `self` can just contain an empty list.

The following examples are invalid:

```graphql
input Example {
  value: String
  self: Example!
}
```

```graphql
input First {
  second: Second!
  value: String
}

input Second {
  first: First!
  value: String
}
```

The following example shows why no possible value can be provided:

```graphql
{
  someField(input: {
    value: "val"
    # self is required
    self: {
      value: "nextval"
      # self is still required
      self: {
        # We would have to recurse down infinitely
        ...
      }
    }
  })
}
```